### PR TITLE
Ember.String methods from ember-inflector now available on String.prototype

### DIFF
--- a/packages/ember-inflector/lib/ext/string.js
+++ b/packages/ember-inflector/lib/ext/string.js
@@ -1,0 +1,61 @@
+require('ember-inflector/system/string');
+
+var pluralize = Ember.String.pluralize,
+	singularize = Ember.String.singularize,
+	humanize = Ember.String.humanize,
+	titleize = Ember.String.titleize,
+	capitalize = Ember.String.capitalize,
+	tableize = Ember.String.tableize,
+	classify = Ember.String.classify;
+
+if (Ember.EXTEND_PROTOTYPES) {
+	
+	/*
+	 * 
+	 */
+	String.prototype.pluralize = function() {
+	  return pluralize(this, arguments);
+	};
+
+	/*
+	 * 
+	 */
+	String.prototype.singularize = function() {
+	  return singularize(this, arguments);
+	};
+
+	/*
+	 * 
+	 */
+	String.prototype.humanize = function() {
+	  return humanize(this, arguments);
+	};
+
+	/*
+	 * 
+	 */
+	String.prototype.titleize = function() {
+	  return titleize(this, arguments);
+	};
+
+	/*
+	 * 
+	 */
+	String.prototype.capitalize = function() {
+	  return capitalize(this, arguments);
+	};
+
+	/*
+	 * 
+	 */
+	String.prototype.tableize = function() {
+	  return tableize(this, arguments);
+	};
+
+	/*
+	 * 
+	 */
+	String.prototype.classify = function() {
+	  return classify(this, arguments);
+	};
+}

--- a/packages/ember-inflector/lib/system.js
+++ b/packages/ember-inflector/lib/system.js
@@ -2,3 +2,4 @@ require('ember-inflector/system/string');
 require('ember-inflector/system/inflector');
 require('ember-inflector/system/inflections');
 require('ember-inflector/ext/ordinalization');
+require('ember-inflector/ext/string');

--- a/packages/ember-inflector/tests/ext/string_test.js
+++ b/packages/ember-inflector/tests/ext/string_test.js
@@ -1,0 +1,65 @@
+module("ember-inflector.integration",{
+  setup: function(){
+    Ember.Inflector.reset();
+    Ember.Inflector.loadAll();
+  },
+  tearDown: function(){
+    Ember.Inflector.reset();
+    Ember.Inflector.clearRules();
+  }
+});
+
+test("pluralize", function(){
+  expect(3);
+
+  equal( 'word'.pluralize(),     'words');
+  equal( 'ox'.pluralize(),       'oxen');
+  equal( 'octopus'.pluralize(),  'octopi');
+});
+
+test("singularize", function(){
+  expect(3);
+
+  equal( 'words'.singularize(),  'word');
+  equal( 'oxen'.singularize(),   'ox');
+  equal( 'octopi'.singularize(), 'octopus');
+});
+
+test("humanize", function(){
+  expect(2);
+
+  equal( ''.humanize(), '');
+  equal( 'word_table'.humanize(), 'Word table');
+});
+
+test("titleize", function(){
+  expect(1);
+
+  equal( 'word_table'.titleize(), 'Word Table');
+});
+
+test("capitalize", function(){
+  expect(3);
+
+  equal(''.capitalize(),'');
+  equal('word'.capitalize(),'Word');
+  equal('word table'.capitalize(),'Word table');
+});
+
+test("tableize", function(){
+  expect(4);
+
+  equal(''.tableize(),'');
+  equal('word'.tableize(),'words');
+  equal('word table'.tableize(),'word_tables');
+  equal('Word Table'.tableize(),'word_tables');
+});
+
+test("classify", function(){
+  expect(4);
+
+  equal(''.classify(),'');
+  equal('word'.classify(),'Word');
+  equal('words'.classify(),'Word');
+  equal('word table'.classify(),'WordTable');
+});


### PR DESCRIPTION
Methods _pluralize_, _singularize_, _humanize_, _titleize_, _capitalize_, _tableize_ and _classify_ from _Ember.String_ are now available on _String.prototype_. Ember framework expose _Ember.String_ methods to _String.prototype_ as well.  

I added tests as well.  

Thanks
