### PR TITLE
added additional tests for inflector to demonstrate bug when specifying ...

### DIFF
--- a/packages/ember-inflector/tests/system/inflector_test.js
+++ b/packages/ember-inflector/tests/system/inflector_test.js
@@ -43,6 +43,21 @@ test('ability to add additonal irregular rules', function(){
 
   equal(inflector.singularize('kine'), 'cow', 'irregular singularization rule was applied');
   equal(inflector.pluralize('cow'), 'kine', 'irregular pluralization rule was applied');
+  equal(inflector.singularize('cow'), 'cow', 'regular singularization is preserved');  
+});
+
+test('ability to add additonal irregular rules', function(){
+  inflector.singular(/s$/, '');
+  inflector.plural(/$/, 's');
+
+  equal(inflector.singularize('campuses'), 'campuse', 'regular singularization rule was applied');
+  equal(inflector.pluralize('campus'), 'campuss', 'regular pluralization rule was applied');
+
+  inflector.irregular('campus', 'campuses');
+  
+  equal(inflector.singularize('campuses'), 'campus', 'irregular singularization rule was applied');
+  equal(inflector.pluralize('campus'), 'campuses', 'irregular pluralization rule was applied');
+  equal(inflector.singularize('campus'), 'campus', 'regular singularization is preserved');  
 });
 
 module('ember-inflector.unit');
@@ -83,6 +98,18 @@ test('singularization of irregulars', function(){
   });
 
   equal(inflector.singularize('person'), 'person');
+});
+
+test('singularization of irregulars with trailing "s"', function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector({
+    irregularPairs: [
+      ['campus', 'campuses']
+    ]
+  });
+
+  equal(inflector.singularize('campus'), 'campus');
 });
 
 test('plural',function(){


### PR DESCRIPTION
added additional tests for inflector to demonstrate bug when specifying irregular inflection on model with trails "s"

see failing spec under 'ability to add additonal irregular rules', interestingly enough the test for 'singularization of irregulars with trailing "s"' passes. potentially not a bug, but expected behavior...
