### PR TITLE
Add 'valve' as irregular word.

### DIFF
--- a/packages/ember-inflector/lib/system/inflections.js
+++ b/packages/ember-inflector/lib/system/inflections.js
@@ -60,7 +60,8 @@ Ember.Inflector.defaultRules = {
     ['sex', 'sexes'],
     ['move', 'moves'],
     ['cow', 'kine'],
-    ['zombie', 'zombies']
+    ['zombie', 'zombies'],
+    ['valve', 'valves']
   ],
 
   uncountable: [


### PR DESCRIPTION
The singular of `valves` is `valve` and not `valf`.
Is this PR desired?
