### PR TITLE
Replace Handlebars pluralize helpers

### DIFF
--- a/packages/ember-inflector/lib/helpers.js
+++ b/packages/ember-inflector/lib/helpers.js
@@ -23,11 +23,25 @@ Ember.Handlebars.helper('singularize', singularize);
  *
  * Example:
  *
+ * {{pluralize count myProperty}}
+ * {{pluralize 1 "oxen"}}
  * {{pluralize myProperty}}
- * {{pluralize "oxen"}}
+ * {{pluralize "ox"}}
  *
  * @for Ember.Handlebars.helpers
  * @method pluralize
+ * @param {Number|Property|} [count] count of objects
  * @param {String|Property} word word to pluralize
 */
-Ember.Handlebars.helper('pluralize', pluralize);
+Ember.Handlebars.helper('pluralize', function(count, word, options) {
+  if(arguments.length < 3) {
+    return pluralize(count);
+  } else {
+    /* jshint eqeqeq: false */
+    if(count != 1) {
+      /* jshint eqeqeq: true */
+      word = pluralize(word);
+    }
+    return count + " " + word;
+  }
+});

--- a/packages/ember-inflector/tests/system/integration_test.js
+++ b/packages/ember-inflector/tests/system/integration_test.js
@@ -30,10 +30,18 @@ module("ember-inflector.integration - Handlebars Helpers", {
     Ember.lookup = lookup = {Ember: Ember};
     run(function(){
       view = Ember.View.create({
-        template: Ember.Handlebars.compile("{{singularize plural}} {{pluralize single}}"),
+        template: Ember.Handlebars.compile("{{singularize plural}} {{pluralize single}} {{pluralize 1 singleArg}} {{pluralize 2 multiple}} {{pluralize one boundSingle}} {{pluralize oneString boundSingleString}} {{pluralize two boundMultiple}}"),
         context: {
           plural: "octopi",
-          single: "ox"
+          single: "ox",
+          singleArg: "opossums",
+          multiple: "ocelot",
+          one: 1,
+          two: 2,
+          oneString: "1.0",
+          boundSingle: "oranges",
+          boundSingleString: "owls",
+          boundMultiple: "omnivore"
         }
       });
 
@@ -52,6 +60,26 @@ test("helpers - singularize", function(){
   ok(text.match(/octopus/));
 });
 
-test("helpers - pluralize", function(){
+test("helpers - pluralize - single arg", function(){
   ok(text.match(/oxen/));
+});
+
+test("helpers - pluralize - one", function(){
+  ok(text.match(/1 opossum/), text);
+});
+
+test("helpers - pluralize - multiple", function(){
+  ok(text.match(/2 ocelots/));
+});
+
+test("helpers - pluralize - boundSingle", function(){
+  ok(text.match(/1 orange/));
+});
+
+test("helpers - pluralize - boundSingle - string", function(){
+  ok(text.match(/1.0 owl/));
+});
+
+test("helpers - pluralize - boundMultiple", function(){
+  ok(text.match(/2 omnivores/));
 });


### PR DESCRIPTION
Replace the handlebars singularize/pluralize helpers with a single pluralise helper that takes two arguments, the count and the word.

I'm not sure the removal is acceptable as it's removing functionality from a released version, but welcome feedback.
