### PR TITLE
Fix failing master

### DIFF
--- a/packages/ember-inflector/lib/main.js
+++ b/packages/ember-inflector/lib/main.js
@@ -22,7 +22,7 @@ export {
   defaultRules
 };
 
-if (typeof 'define' !== 'undefined' && define.amd){
+if (typeof define !== 'undefined' && define.amd){
   define('ember-inflector', ['exports'], function(__exports__){
     __exports__['default'] = Inflector;
     return Inflector;

--- a/tests/index.html
+++ b/tests/index.html
@@ -77,9 +77,6 @@
 
   <script type="text/javascript" src="/ember-inflector.js"></script>
   <script type="text/javascript" src="/ember-inflector.jshint.js"></script>
-  <script type="text/javascript">
-  requireModule('ember-inflector');
-  </script>
   <script type="text/javascript" src="/tests.js"></script>
 
   <script type="text/javascript">


### PR DESCRIPTION
`typeof 'define'` is always "string" :grin:.

`requireModule` wasn't define either.
