### PR TITLE
Remove count from pluralize helper result

### DIFF
--- a/addon/lib/helpers/pluralize.js
+++ b/addon/lib/helpers/pluralize.js
@@ -32,6 +32,6 @@ export default makeHelper(function (params) {
       word = pluralize(word);
     }
 
-    return count + " " + word;
+    return word;
   }
 });


### PR DESCRIPTION
I assume this is a bug:

``` html
{{pluralize 2 "test"}}
```

Outputs:

```
2 tests
```

I just want:

```
tests
```

Other users can install it with:

``` bash
npm install git+https://github.com/Glavin001/ember-inflector.git#patch-1
```

And if you want the original behaviour then:

``` html
{{count}} {{pluralize count "test"}}
```
