### PR TITLE
Return the same output format for `defined.amd` environments.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -30,7 +30,7 @@ if (typeof define !== 'undefined' && define.amd){
     __exports__.pluralize = pluralize;
     __exports__.singularize = singularize;
 
-    return Inflector;
+    return __exports__;
   });
 } else if (typeof module !== 'undefined' && module['exports']){
   module['exports'] = Inflector;


### PR DESCRIPTION
`ember-inflector` AMD module in `define.amd` environments is returning a different output format as opposed to non `define.amd` format.

cc: @rwjblue @stefanpenner @msranade