### PR TITLE
Fix to update URL to ember-inflector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,4 @@ CHANGELOG
 
 ## 1.9.6 (August 3, 2016)
 
-- Fix "bonus" inflection. - [#108](https://github.com/stefanpenner/ember-inflector/pull/108)
+- Fix "bonus" inflection. - [#108](https://github.com/emberjs/ember-inflector/pull/108)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember Inflector [![Build Status](https://travis-ci.org/stefanpenner/ember-inflector.png?branch=master)](https://travis-ci.org/stefanpenner/ember-inflector)
+# Ember Inflector [![Build Status](https://travis-ci.org/emberjs/ember-inflector.png?branch=master)](https://travis-ci.org/emberjs/ember-inflector)
 
 Ember Inflector is a library for inflecting words between plural and singular forms. Ember Inflector aims to be compatible with [ActiveSupport::Inflector](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html) from Ruby on Rails, including the ability to add your own inflections in your app.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/stefanpenner/ember-inflector.git"
+    "url": "git://github.com/emberjs/ember-inflector.git"
   },
   "scripts": {
     "build": "ember build",


### PR DESCRIPTION
Now ember-inflector is managed by emberjs organization.