### PR TITLE
Fix missing array wrapper in documentation

### DIFF
--- a/addon/lib/system/inflector.js
+++ b/addon/lib/system/inflector.js
@@ -73,8 +73,12 @@ function loadIrregular(rules, irregularPairs) {
 
   ```javascript
   var rules = {
-    plurals:  [ /$/, 's' ],
-    singular: [ /\s$/, '' ],
+    plurals:  [
+      [ /$/, 's' ]
+    ],
+    singular: [
+      [ /\s$/, '' ]
+    ],
     irregularPairs: [
       [ 'cow', 'kine' ]
     ],


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember-inflector/pull/117.