### PR TITLE
Fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Ember.Inflector.inflector.pluralize("taco"); // tacos
 ```
 
 ###Template Helpers
+
 ####pluralize
 
 Pluralize a word

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ pluralize("taco"); // tacos
 Ember.Inflector.inflector.pluralize("taco"); // tacos
 ```
 
-###Template Helpers
+### Template Helpers
 
-####pluralize
+#### pluralize
 
 Pluralize a word
 ```helpers
@@ -49,7 +49,7 @@ Specify a count with the word, with the pluralization being based on the number 
 {{pluralize 2 "taco" without-count=true}} //tacos
 ```
 
-####singularize
+#### singularize
 ```helpers
 {{singularize 'octopi'}} //octopus
 ```


### PR DESCRIPTION
My markdown editor was showing the README fine, but I had messed up the spacing. Simple fix to 3 headers. 