### PR TITLE
Update to use Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "test": "ember try:each"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 4"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^6.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -32,7 +32,7 @@
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",


### PR DESCRIPTION
This addon is built-in (included by ember-data by default). We are trying to update all prebuilt addons to ember-cli-babel@6 for the ember-cli@2.13 release.

This also bumps the engine minimum (since ember-cli-babel uses ES6), and therefore will need to be a major version bump.