### PR TITLE
Remove broken AMD and CJS exports

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,3 @@
-/* global define, module */
-
 import Ember from 'ember';
 import {
   Inflector,
@@ -23,17 +21,3 @@ export {
   singularize,
   defaultRules
 };
-
-if (typeof define !== 'undefined' && define.amd){
-  define('ember-inflector', ['exports'], function(__exports__){
-    __exports__['default'] = Inflector;
-    __exports__.pluralize = pluralize;
-    __exports__.singularize = singularize;
-
-    return __exports__;
-  });
-} else if (typeof module !== 'undefined' && module['exports']){
-  module['exports'] = Inflector;
-  Inflector.singularize = singularize;
-  Inflector.pluralize = pluralize;
-}


### PR DESCRIPTION
The CJS export could never worked without transpiling the ES6 imports above it and if you transpile them you would also transpile the ES6 exports which makes the manual CJS export pointless.

The AMD export is also unneeded since we use `ember-cli-babel` and the file is in the `addon` folder which will automatically be transpiled into AMD modules.

/cc @rwjblue 