### PR TITLE
Add typing definition file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+export function pluralize(someString: string): string;
+export function singularize(someString: string): string;


### PR DESCRIPTION
Adding this will make imports work nicely and automatically for any TypeScript consumers of the addon—no additional work required besides just installing the package!