### PR TITLE
Adds a failing test for irregularPairs if the word is capitalized

### DIFF
--- a/tests/unit/inflector-test.js
+++ b/tests/unit/inflector-test.js
@@ -564,3 +564,10 @@ test('Ember.Inflector.singularize can pluralize "bonus"', function(assert) {
 
   assert.equal(inflector.pluralize('bonus'), 'bonuses');
 });
+
+test('Ember.Inflector preserve capitalized version for irregularPairs', function(assert) {
+  var inflector = new Ember.Inflector(Ember.Inflector.defaultRules);
+
+  assert.equal(inflector.pluralize('Child'), 'Children');
+  assert.equal(inflector.singularize('Children'), 'Child');
+});


### PR DESCRIPTION
I'm not sure how we should fix it so I just added a failing test to demonstrate #135