### PR TITLE
✨ inflector.pluralize accepts count, withoutCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Inflector.inflector.pluralize("taco"); // tacos
 
 singularize("tacos"); // taco
 pluralize("taco"); // tacos
+
+pluralize(2, "taco"); // 2 tacos
+pluralize(2, "tacos", { withoutCount: true }); // tacos
 ```
 
 ### Template Helpers

--- a/addon/lib/helpers/pluralize.js
+++ b/addon/lib/helpers/pluralize.js
@@ -19,23 +19,11 @@ import makeHelper from '../utils/make-helper';
  * @param {String|Property} word word to pluralize
  */
 export default makeHelper(function (params, hash) {
-  let count, word,withoutCount=false;
+  let fullParams = new Array(...params);
 
-  if (params.length === 1) {
-    word = params[0];
-    return pluralize(word);
-  } else {
-    count = params[0];
-    word  = params[1];
-
-    if(hash["without-count"]){
-      withoutCount = hash["without-count"];
-    }
-
-    if (parseFloat(count) !== 1) {
-      word = pluralize(word);
-    }
-
-    return withoutCount ? word : count + " " + word;
+  if (fullParams.length === 2) {
+    fullParams.push({ withoutCount: hash["without-count"] })
   }
+
+  return pluralize(...fullParams);
 });

--- a/addon/lib/system/inflector.js
+++ b/addon/lib/system/inflector.js
@@ -138,9 +138,10 @@ Inflector.prototype = {
       return this._sCache[word] || (this._sCache[word] = this._singularize(word));
     };
 
-    this.pluralize = function(word) {
+    this.pluralize = function(numberOrWord, word, options = {}) {
       this._cacheUsed = true;
-      return this._pCache[word] || (this._pCache[word] = this._pluralize(word));
+      var cacheKey = [numberOrWord, word, options.withoutCount]
+      return this._pCache[cacheKey] || (this._pCache[cacheKey] = this._pluralize(numberOrWord, word, options));
     };
   },
 
@@ -168,8 +169,8 @@ Inflector.prototype = {
       return this._singularize(word);
     };
 
-    this.pluralize = function(word) {
-      return this._pluralize(word);
+    this.pluralize = function() {
+      return this._pluralize(...arguments);
     };
   },
 
@@ -216,12 +217,20 @@ Inflector.prototype = {
     @method pluralize
     @param {String} word
   */
-  pluralize: function(word) {
-    return this._pluralize(word);
+  pluralize: function() {
+    return this._pluralize(...arguments);
   },
 
-  _pluralize: function(word) {
-    return this.inflect(word, this.rules.plurals, this.rules.irregular);
+  _pluralize: function(wordOrCount, word, options = {}) {
+    if (word === undefined) {
+     return this.inflect(wordOrCount, this.rules.plurals, this.rules.irregular);
+    }
+
+    if (parseFloat(wordOrCount) !== 1) {
+      word = this.inflect(word, this.rules.plurals, this.rules.irregular);
+    }
+
+    return options.withoutCount ? word : `${wordOrCount} ${word}`;
   },
   /**
     @method singularize

--- a/addon/lib/system/string.js
+++ b/addon/lib/system/string.js
@@ -1,7 +1,7 @@
 import Inflector from './inflector';
 
-function pluralize(word) {
-  return Inflector.inflector.pluralize(word);
+function pluralize() {
+  return Inflector.inflector.pluralize(...arguments);
 }
 
 function singularize(word) {

--- a/tests/unit/inflector-test.js
+++ b/tests/unit/inflector-test.js
@@ -14,6 +14,13 @@ module('ember-inflector.dsl', {
   }
 });
 
+test('ability to include counts', function(assert) {
+  inflector.plural(/$/, 's');
+  assert.equal(inflector.pluralize(1, 'cat'), '1 cat', 'pluralize 1')
+  assert.equal(inflector.pluralize(5, 'cat'), '5 cats', 'pluralize 5')
+  assert.equal(inflector.pluralize(5, 'cat', { withoutCount: true }), 'cats', 'without count')
+})
+
 test('ability to add additional pluralization rules', function(assert){
   assert.equal(inflector.pluralize('cow'), 'cow', 'no pluralization rule');
 


### PR DESCRIPTION
The `{{pluralize}}` helper accepts a count:

```hbs
{{pluralize 4 'chicken'}}
{{pluralize 1 'pig' without-count=true}}
```

This commit makes that same API available to the `inflector.pluralize()` JavaScript function.

Closes #122
Closes #124