### PR TITLE
👷 Travis: require sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:


### PR DESCRIPTION
Chrome's sandbox feature requires root access. My hope is that this will fix [the build for #140](https://travis-ci.org/emberjs/ember-inflector/builds/358501698):

> [0326/165542.575101:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755.