### PR TITLE
Avoid using legacy global flags

### DIFF
--- a/addon/lib/ext/string.js
+++ b/addon/lib/ext/string.js
@@ -4,7 +4,7 @@ import {
   singularize
 } from '../system/string';
 
-if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
+if (Ember.ENV.EXTEND_PROTOTYPES === true || Ember.ENV.EXTEND_PROTOTYPES.String) {
   /**
     See {{#crossLink "Ember.String/pluralize"}}{{/crossLink}}
 


### PR DESCRIPTION
Several flags (including `EXTEND_PROTOTYPES`) underneath the Ember namespace have been removed in Ember 3.2.
https://github.com/emberjs/ember.js/pull/16467

Fixed #142 