### PR TITLE
Bugfix: adding deprecations won't throw on multiple installed copies …

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -19,7 +19,7 @@ Object.defineProperty(Ember, 'Inflector', {
 
     return Inflector;
   },
-});
+}, { configurable: true });
 
 Object.defineProperty(Ember.String, 'singularize', {
   get() {
@@ -30,7 +30,7 @@ Object.defineProperty(Ember.String, 'singularize', {
 
     return singularize;
   },
-});
+}, { configurable: true });
 
 Object.defineProperty(Ember.String, 'pluralize', {
   get() {
@@ -41,7 +41,7 @@ Object.defineProperty(Ember.String, 'pluralize', {
 
     return pluralize;
   },
-});
+}, { configurable: true });
 
 import "./lib/ext/string";
 

--- a/addon/lib/ext/string.js
+++ b/addon/lib/ext/string.js
@@ -23,7 +23,7 @@ if (Ember.ENV.EXTEND_PROTOTYPES === true || Ember.ENV.EXTEND_PROTOTYPES.String) 
         return pluralize(this);
       };
     },
-  });
+  }, { configurable: true });
 
   /**
     See {{#crossLink "Ember.String/singularize"}}{{/crossLink}}
@@ -42,5 +42,5 @@ if (Ember.ENV.EXTEND_PROTOTYPES === true || Ember.ENV.EXTEND_PROTOTYPES.String) 
         return singularize(this);
       };
     },
-  });
+  }, { configurable: true });
 }


### PR DESCRIPTION
This work should target 3.0.0 as a patch release candidate. It should not be merged to master, since some of the code is removed in unreleased #154 (a major release candidate). 

## Why this is needed

If two copies of ember-inflector are running, defineProperty will throw since the prototype is already defined. Passing `{configurable: true}` will allow it to get rewritten and therefore not throw. This will help people who are using local `yarn link`s. See #182 for details.

Closes #182 
