### PR TITLE
Add 'info' as uncountable word

### DIFF
--- a/addon/lib/system/inflections.js
+++ b/addon/lib/system/inflections.js
@@ -66,6 +66,7 @@ export default {
   uncountable: [
     'equipment',
     'information',
+    'info',
     'rice',
     'money',
     'species',


### PR DESCRIPTION
source https://en.wiktionary.org/wiki/info 

It's pretty common word in APIs and it would be nice to handle it correctly by default.