### PR TITLE
Drop Node 4, 6, 7, 8, 9, 11, and 13 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "10.* || 12.* || >= 14"
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0"


### PR DESCRIPTION
```yaml
  # we recommend testing addons with the same minimum supported node version as Ember CLI
  # so that your addon works for all apps
```
We have this comment on the TravisCI configuration, but the version was still stuck on `4` while ember-cli seems to have moved (go to https://github.com/ember-cli/ember-cli/find/master, press `t`, type `travis.yml` and inspect those files).
This doesn’t fix the tests yet — it only allows us to run them, since they were not running at the moment. My follow-up pull request will fix them.