### PR TITLE
Update TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-sudo: false
+os: linux
 dist: trusty
 
 addons:
@@ -18,7 +18,7 @@ env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
-  matrix:
+  jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - EMBER_TRY_SCENARIO=ember-lts-2.12
@@ -29,7 +29,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary


### PR DESCRIPTION
A few things were changed, based on the info displayed on TravisCI:
- `sudo` no longer needed
- `os` key was missing (linux was default, so let’s make it explicit)
- `matrix` is an alias for the more up to date `jobs`

|before|after|
|:-:|:-:|
|![Screen Shot 2020-10-23 at 15 40 53](https://user-images.githubusercontent.com/385232/97027077-2a882880-1552-11eb-9b42-d8d0bdf12abc.png)|![image](https://user-images.githubusercontent.com/385232/97027110-3378fa00-1552-11eb-9f2d-1e943c92a505.png)|
