### PR TITLE
fixing invalid import

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,11 +1,11 @@
 import {
   Inflector,
-  defaultRules,
   pluralize,
   singularize
 } from "./lib/system";
 
 export default Inflector;
+const { defaultRules } = Inflector;
 
 export {
   pluralize,


### PR DESCRIPTION
There is no `defaultRules` export from `./lib/system`, so this was a `SyntaxError` in any system that faithfully follows the module spec.