### PR TITLE
Remove non-existing `defaultRules` re-export

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,5 @@
 import {
   Inflector,
-  defaultRules,
   pluralize,
   singularize
 } from "./lib/system";
@@ -9,6 +8,5 @@ export default Inflector;
 
 export {
   pluralize,
-  singularize,
-  defaultRules
+  singularize
 };


### PR DESCRIPTION
To fix this warning when using embroider:

```
WARNING in ./node_modules/ember-inflector/index.js 4:0-48
export 'defaultRules' (reexported as 'defaultRules') was not found in './lib/system' (possible exports: Inflector, pluralize, singularize)
```