### PR TITLE
Add test watch-mode and 'software' in uncountable words

### DIFF
--- a/ember-inflector/src/lib/system/inflections.js
+++ b/ember-inflector/src/lib/system/inflections.js
@@ -77,5 +77,6 @@ export default {
     'sheep',
     'jeans',
     'police',
+    'software',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start:addon": "pnpm --filter ember-inflector start --no-watch.clearScreen",
     "start:test-app": "pnpm --filter test-app start",
     "test": "pnpm --filter '*' test",
-    "test:ember": "pnpm --filter '*' test:ember"
+    "test:ember": "pnpm --filter '*' test:ember",
+    "test:watch": "pnpm --filter '*' test:watch"
   },
   "devDependencies": {
     "concurrently": "^8.2.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -20,7 +20,8 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
-    "test:ember": "ember test"
+    "test:ember": "ember test",
+    "test:watch": "ember test --server"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",


### PR DESCRIPTION
**What is added ?**
`ember test --server` in the `package.json` file as a `pnpm` command. We can now run it by executing `pnpm run test:watch`.

**What is fixed ?**
'Software' was being _pluralized_ as `Softwares` whereas it is an uncountable Noun. Fixed that.