### PR TITLE
Restore repository and author fields in package.json

### DIFF
--- a/ember-inflector/package.json
+++ b/ember-inflector/package.json
@@ -5,9 +5,12 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/emberjs/ember-inflector.git"
+  },
   "license": "MIT",
-  "author": "",
+  "author": "Stefan Penner, Manuel Wiedenmann and Trace Wax",
   "exports": {
     ".": {
       "types": "./src/index.d.ts",


### PR DESCRIPTION
Seem like these got lost during conversion to v2 format