### PR TITLE
Added meta to the uncountable array because "metum" is not a word.

### DIFF
--- a/ember-inflector/src/lib/system/inflections.js
+++ b/ember-inflector/src/lib/system/inflections.js
@@ -77,6 +77,6 @@ export default {
     'sheep',
     'jeans',
     'police',
-    'meta'
+    'meta',
   ],
 };

--- a/ember-inflector/src/lib/system/inflections.js
+++ b/ember-inflector/src/lib/system/inflections.js
@@ -77,5 +77,6 @@ export default {
     'sheep',
     'jeans',
     'police',
+    'meta'
   ],
 };


### PR DESCRIPTION
Added 'meta' to uncountable so it doesn't turn it into metum, which is not a word at least not in the typical programming sense when people use the word "meta" like "meta data" 

Tests all passed for this change. 

There was an issue mentioned previously about this usage here - https://github.com/emberjs/ember-inflector/issues/67

Which leads to the rails convention this library is keen on following. But the convention is wrong, they just refuse to fix it because it will break existing applications as mentioned here - https://github.com/rails/rails/issues/34914

Though I'm not sure why they don't just create some sort of a deprecation warning. (I'm not a rails developer) 

Anyone else who is running into this issue in the meantime can create a `inflector-rules.js` file inside of their `app/initializers/ ` directory (create it if it doesn't exist) and add the following code as a work-around. 

```js
import Inflector from 'ember-inflector';

export function initialize() {
  const inflector = Inflector.inflector;

  inflector.irregular('meta', 'meta');
}

export default {
  name: 'inflector-rules',
  initialize
};

```